### PR TITLE
Add aptitude_code option to aptitude items

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -15,6 +15,7 @@
   "ADVANCE.VETERAN": "Veteran",
 
   "APTITUDE.NAME": "Name",
+  "APTITUDE.CODE": "Code",
 
   "AIMING.NONE" : "None",
   "AIMING.HALF" : "Half",

--- a/lang/es.json
+++ b/lang/es.json
@@ -10,6 +10,7 @@
   "ADVANCE.VETERAN": "Veterana",
 
   "APTITUDE.NAME": "Nombre",
+  "APTITUDE.CODE": "Código",
 
   "AMMUNITION.HEADER": "Munición",
   "AMMUNITION.NAME": "Nombre",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -10,6 +10,7 @@
     "ADVANCE.VETERAN": "Vétéran",
   
     "APTITUDE.NAME": "Nom",
+    "APTITUDE.CODE": "Code",
   
     "AMMUNITION.HEADER": "Munitions",
     "AMMUNITION.NAME": "Nom",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -33,6 +33,7 @@
   "ADVANCE.VETERAN": "Weteran",
 
   "APTITUDE.NAME": "Nazwa",
+  "APTITUDE.CODE": "Kod",
 
   "AMMUNITION.HEADER": "Amunicja",
   "AMMUNITION.NAME": "Nazwa",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -15,6 +15,7 @@
   "ADVANCE.VETERAN": "Ветеран",
 
   "APTITUDE.NAME": "Имя",
+  "APTITUDE.CODE": "Код",
 
   "AIMING.NONE" : "None",
   "AIMING.HALF" : "Half",

--- a/src/packs/aptitudes/aptitudes.yaml
+++ b/src/packs/aptitudes/aptitudes.yaml
@@ -6,6 +6,7 @@ type: aptitude
 system: 
   description: <p>Versed in all-out assault of brute force over a more careful, strategic approach.</p>
   source: ""
+  aptitude_code: Offence
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -19,6 +20,7 @@ type: aptitude
 system: 
   description: <p>A knack for persuasiveness, ability to lead, and force of personality.</p>
   source: ""
+  aptitude_code: Fellowship
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -32,6 +34,7 @@ type: aptitude
 system: 
   description: <p>An aptitude for skillful deterrence or dogged toughness to keep themselves alive.</p>
   source: ""
+  aptitude_code: Defence
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -45,6 +48,7 @@ type: aptitude
 system: 
   description: <p>Those characters with the Tech aptitude might not understand the inner workings of machines, but they can easily learn to commune with the machine spirit, and seem to get results where others gain only frustration.</p>
   source: ""
+  aptitude_code: Tech
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -58,6 +62,7 @@ type: aptitude
 system: 
   description: <p>Skilled at acquiring information from the countless worlds and labyrinthine organisations within the Imperium.</p>
   source: ""
+  aptitude_code: Knowledge
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -71,6 +76,7 @@ type: aptitude
 system: 
   description: <p>Talented at physical prowess.</p>
   source: ""
+  aptitude_code: Strength
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -84,6 +90,7 @@ type: aptitude
 system: 
   description: <p>Learned with acumen, reason, and general knowledge.</p>
   source: ""
+  aptitude_code: Intelligence
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -97,6 +104,7 @@ type: aptitude
 system: 
   description: <p>Only those with the rare ability to wield psychic powers gain the Psyker aptitude, representing their affinity with the terrible powers of the Warp</p>
   source: ""
+  aptitude_code: Psyker
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -110,6 +118,7 @@ type: aptitude
 system: 
   description: <p>An aptitude for awareness and the acuteness of senses</p>
   source: ""
+  aptitude_code: Perception
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -123,6 +132,7 @@ type: aptitude
 system: 
   description: <p>Competent in all forms of close-quarters combat. Characters with high Weapon Skill values are excellent warriors, renowned with a chainsword or even their bare hands.</p>
   source: ""
+  aptitude_code: Weapon Skill
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -136,6 +146,7 @@ type: aptitude
 system: 
   description: <p>Gifted at using precise skill and careful planning.</p>
   source: ""
+  aptitude_code: Finesse
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -149,6 +160,7 @@ type: aptitude
 system: 
   description: <p>An aptitude for quickness, reflex, and poise.</p>
   source: ""
+  aptitude_code: Agility
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -162,6 +174,7 @@ type: aptitude
 system: 
   description: <p>An aptitude for mental strength and resilience.</p>
   source: ""
+  aptitude_code: Willpower
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -175,6 +188,7 @@ type: aptitude
 system: 
   description: <p>Talented at easily adjusting to, and thriving on, a myriad of settings and terrains.</p>
   source: ""
+  aptitude_code: Fieldcraft
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -188,6 +202,7 @@ type: aptitude
 system: 
   description: <p>An aptitude for health, stamina, and resistance.</p>
   source: ""
+  aptitude_code: Toughness
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -201,6 +216,7 @@ type: aptitude
 system: 
   description: <p>An aptitude with all forms of ranged weapons.</p>
   source: ""
+  aptitude_code: Ballistic Skill
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -214,6 +230,7 @@ type: aptitude
 system: 
   description: <p>Adept at commanding even cowering citizens into a vengeful force ready to attack or defend.</p>
   source: ""
+  aptitude_code: Leadership
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -227,6 +244,7 @@ type: aptitude
 system: 
   description: <p>Able to best use honeyed words or harsh intimidation to get their way with those requiring more subtle means of persuasion.</p>
   source: ""
+  aptitude_code: Social
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 
@@ -240,6 +258,7 @@ type: aptitude
 system: 
   description: <p>Those skills and talents with the General aptitude represent advances that are simple to learn, regardless of the background or aptitude of the character gaining them.</p>
   source: ""
+  aptitude_code: General
 flags: {} 
 img: systems/dark-heresy/asset/icons/aptitudes/aptitude400.png
 effects: [] 

--- a/template.json
+++ b/template.json
@@ -1239,7 +1239,8 @@
       "installed": false
     },
     "aptitude" : {
-      "templates": ["itemDescription"]
+      "templates": ["itemDescription"],
+      "aptitude_code": ""
     }
   }
 }

--- a/template/sheet/aptitude.hbs
+++ b/template/sheet/aptitude.hbs
@@ -9,6 +9,32 @@
                     <label>{{localize "APTITUDE.NAME"}}</label>
                     <input name="name" type="text" value="{{item.name}}" />
                 </div>
+                <div class="code header-row">
+                    <label>{{localize "APTITUDE.CODE"}}</label>
+                    <select name="system.aptitude_code">
+                        {{#select system.aptitude_code}}
+                            <option value="Offence">Offence</option>
+                            <option value="Fellowship">Fellowship</option>
+                            <option value="Defence">Defence</option>
+                            <option value="Tech">Tech</option>
+                            <option value="Knowledge">Knowledge</option>
+                            <option value="Strength">Strength</option>
+                            <option value="Intelligence">Intelligence</option>
+                            <option value="Psyker">Psyker</option>
+                            <option value="Perception">Perception</option>
+                            <option value="Weapon Skill">Weapon Skill</option>
+                            <option value="Finesse">Finesse</option>
+                            <option value="Agility">Agility</option>
+                            <option value="Willpower">Willpower</option>
+                            <option value="Fieldcraft">Fieldcraft</option>
+                            <option value="Toughness">Toughness</option>
+                            <option value="Ballistic Skill">Ballistic Skill</option>
+                            <option value="Leadership">Leadership</option>
+                            <option value="Social">Social</option>
+                            <option value="General">General</option>
+                        {{/select}}
+                    </select>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
- Added `aptitude_code` field to aptitude schema
- Updated aptitude compendium data with the new property
- Added display of `aptitude_code` on Aptitude sheet via dropdown
- Added translations for the new label
